### PR TITLE
Included numOfCoverpoints in cluster response

### DIFF
--- a/src/routes.mjs
+++ b/src/routes.mjs
@@ -20,7 +20,7 @@ router.get("/cover-groups", (_req, res) => {
 });
 
 router.get("/covergroup-heatmap", (req, res) => {
-  let { size } = req.query;
+  const { size } = req.query;
   const half = Math.floor(COVERGROUPS.length / 2);
   const threeFourth = Math.floor(COVERGROUPS.length / 3);
   size = size || half;
@@ -48,12 +48,21 @@ router.get("/cover-groups/:cgId/clusters", (req, res) => {
   }
 
   const clusters = cvg.clusters.map(cl => {
+    const uniqueCoverpoints = new Set();
+    cl.crosses.forEach(cross => {
+      cross.coverpoints.forEach(cp => {
+        uniqueCoverpoints.add(cp.id);
+      });
+    });
+  
     return {
       id: cl.id,
       name: cl.name,
-      numOfCrosses: cl.crosses.length
-    }
+      numOfCrosses: cl.crosses.length,
+      numOfCoverpoints: uniqueCoverpoints.size
+    };
   });
+  
   return res.status(200).json(clusters);
 });
 


### PR DESCRIPTION
This PR updates the **/cover-groups/:cgId/clusters** API route to include field numOfCoverpoints for each cluster. This will enable us to display the number of cover points in the Cluster UI Panel instead of the ID field we used to display. This change was requested last demo. Thank you!